### PR TITLE
Add Ionic skeleton with key pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# nutriIA
+# NutriScan AI
+
+Estructura básica para una app móvil Ionic + Capacitor orientada a nutrición.
+
+## Carpetas principales
+
+- **src/components**: componentes reutilizables (gráficos, tarjetas)
+- **src/pages**: páginas de navegación (P1-P9)
+- **src/services**: servicios de base de datos, escáner, OCR y recomendaciones
+- **src/data/sqlite**: base de datos local de ejemplo
+
+Cada página se implementa como componente React con ejemplos de estados y navegación.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,24 @@
+// src/App.tsx
+// Entry point of NutriScan AI app with basic routing
+
+import { IonApp, IonRouterOutlet } from '@ionic/react';
+import { IonReactRouter } from '@ionic/react-router';
+import { Route } from 'react-router-dom';
+import { WelcomePage } from './pages/WelcomePage';
+import { MainMenu } from './pages/MainMenu';
+import { ProfileSetup } from './pages/ProfileSetup';
+import { SearchProduct } from './pages/SearchProduct';
+
+export const App: React.FC = () => (
+  <IonApp>
+    <IonReactRouter>
+      <IonRouterOutlet>
+        <Route exact path="/" component={WelcomePage} />
+        <Route path="/menu" component={MainMenu} />
+        <Route path="/profile" component={ProfileSetup} />
+        <Route path="/search" component={SearchProduct} />
+        {/* TODO: more routes for other pages */}
+      </IonRouterOutlet>
+    </IonReactRouter>
+  </IonApp>
+);

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -1,0 +1,22 @@
+// src/components/ProductCard.tsx
+// Displays product summary with score and quick actions
+
+import { IonCard, IonCardHeader, IonCardTitle, IonCardContent, IonButton } from '@ionic/react';
+import { ProductInfo } from '../services/recommendations';
+
+interface ProductCardProps {
+  product: ProductInfo;
+  onSelect?: () => void;
+}
+
+export const ProductCard: React.FC<ProductCardProps> = ({ product, onSelect }) => (
+  <IonCard>
+    <IonCardHeader>
+      <IonCardTitle>{product.name}</IonCardTitle>
+    </IonCardHeader>
+    <IonCardContent>
+      {/* TODO: show score and summary */}
+      <IonButton onClick={onSelect}>Ver detalle</IonButton>
+    </IonCardContent>
+  </IonCard>
+);

--- a/src/components/RadarChart.tsx
+++ b/src/components/RadarChart.tsx
@@ -1,0 +1,14 @@
+// src/components/RadarChart.tsx
+// Reusable radar chart component using Chart.js
+
+import { Radar } from 'react-chartjs-2';
+import { ChartData, ChartOptions } from 'chart.js';
+
+interface RadarChartProps {
+  data: ChartData<'radar'>;
+  options?: ChartOptions<'radar'>;
+}
+
+export const RadarChart: React.FC<RadarChartProps> = ({ data, options }) => {
+  return <Radar data={data} options={options} />;
+};

--- a/src/data/sqlite/seed.sql
+++ b/src/data/sqlite/seed.sql
@@ -1,0 +1,24 @@
+-- src/data/sqlite/seed.sql
+-- Example seed data for local SQLite database
+CREATE TABLE IF NOT EXISTS products (
+  id INTEGER PRIMARY KEY,
+  barcode TEXT UNIQUE,
+  name TEXT,
+  sugar REAL,
+  fat REAL,
+  salt REAL,
+  fiber REAL,
+  protein REAL
+);
+
+INSERT INTO products (barcode, name, sugar, fat, salt, fiber, protein) VALUES
+  ('0001', 'Cereal Saludable', 5, 2, 0.5, 4, 3),
+  ('0002', 'Bebida Energética', 25, 0, 0.2, 0, 1),
+  ('0003', 'Galletas', 12, 8, 0.3, 1, 2),
+  ('0004', 'Yogur Light', 8, 1, 0.1, 0, 5),
+  ('0005', 'Barrita Proteica', 6, 3, 0.2, 2, 10),
+  ('0006', 'Refresco', 30, 0, 0.1, 0, 0),
+  ('0007', 'Snacks', 2, 15, 1, 1, 3),
+  ('0008', 'Ensalada Lista', 2, 0.5, 0.3, 3, 2),
+  ('0009', 'Pan Integral', 4, 1, 0.5, 5, 4),
+  ('0010', 'Jugo Natural', 18, 0, 0, 1, 1);

--- a/src/pages/FrequentList.tsx
+++ b/src/pages/FrequentList.tsx
@@ -1,0 +1,24 @@
+// src/pages/FrequentList.tsx
+// P5: Lista de productos y comidas frecuentes
+
+import { IonPage, IonContent, IonList, IonItem } from '@ionic/react';
+import { ProductInfo } from '../services/recommendations';
+
+interface Props {
+  items: ProductInfo[];
+  onSelect: (p: ProductInfo) => void;
+}
+
+export const FrequentList: React.FC<Props> = ({ items, onSelect }) => (
+  <IonPage>
+    <IonContent>
+      <IonList>
+        {items.map(p => (
+          <IonItem button key={p.name} onClick={() => onSelect(p)}>
+            {p.name}
+          </IonItem>
+        ))}
+      </IonList>
+    </IonContent>
+  </IonPage>
+);

--- a/src/pages/IngredientAnalysis.tsx
+++ b/src/pages/IngredientAnalysis.tsx
@@ -1,0 +1,24 @@
+// src/pages/IngredientAnalysis.tsx
+// P9: Lista detallada de ingredientes con análisis inteligente
+
+import { IonPage, IonContent, IonList, IonItem, IonLabel } from '@ionic/react';
+import { ProductInfo } from '../services/recommendations';
+
+interface Props {
+  product: ProductInfo;
+}
+
+export const IngredientAnalysis: React.FC<Props> = ({ product }) => (
+  <IonPage>
+    <IonContent className="ion-padding">
+      <IonList>
+        {Object.entries(product.nutrients).map(([key, value]) => (
+          <IonItem key={key}>
+            <IonLabel>{key}: {value}</IonLabel>
+          </IonItem>
+        ))}
+      </IonList>
+      {/* TODO: add intelligent observations like 'Alto en azúcar' */}
+    </IonContent>
+  </IonPage>
+);

--- a/src/pages/MainMenu.tsx
+++ b/src/pages/MainMenu.tsx
@@ -1,0 +1,42 @@
+// src/pages/MainMenu.tsx
+// P2: Menú principal con íconos grandes para cada función
+
+import { IonPage, IonContent, IonGrid, IonRow, IonCol, IonButton, IonIcon } from '@ionic/react';
+import { camera, search, time, menu } from 'ionicons/icons';
+import { useHistory } from 'react-router';
+
+export const MainMenu: React.FC = () => {
+  const history = useHistory();
+  return (
+    <IonPage>
+      <IonContent className="ion-padding">
+        <IonGrid>
+          <IonRow>
+            <IonCol>
+              <IonButton expand="block" onClick={() => history.push('/scan')}>
+                <IonIcon icon={camera} /> Escanear
+              </IonButton>
+            </IonCol>
+            <IonCol>
+              <IonButton expand="block" onClick={() => history.push('/search')}>
+                <IonIcon icon={search} /> Buscar
+              </IonButton>
+            </IonCol>
+          </IonRow>
+          <IonRow>
+            <IonCol>
+              <IonButton expand="block" onClick={() => history.push('/history')}>
+                <IonIcon icon={time} /> Historial
+              </IonButton>
+            </IonCol>
+            <IonCol>
+              <IonButton expand="block" onClick={() => history.push('/menu')}>
+                <IonIcon icon={menu} /> Menú
+              </IonButton>
+            </IonCol>
+          </IonRow>
+        </IonGrid>
+      </IonContent>
+    </IonPage>
+  );
+};

--- a/src/pages/OcrCapture.tsx
+++ b/src/pages/OcrCapture.tsx
@@ -1,0 +1,27 @@
+// src/pages/OcrCapture.tsx
+// P8: Captura de foto para OCR cuando no se encuentra el producto
+
+import { IonPage, IonContent, IonButton } from '@ionic/react';
+import { useState } from 'react';
+import { recognizeText } from '../services/ocr';
+
+export const OcrCapture: React.FC = () => {
+  const [text, setText] = useState('');
+
+  const capture = async () => {
+    // TODO: use Capacitor camera to take photo
+    // Placeholder: assume we have a Blob image
+    const image = new Blob();
+    const result = await recognizeText(image);
+    setText(result);
+  };
+
+  return (
+    <IonPage>
+      <IonContent className="ion-padding">
+        <IonButton onClick={capture}>Capturar etiqueta</IonButton>
+        <pre>{text}</pre>
+      </IonContent>
+    </IonPage>
+  );
+};

--- a/src/pages/ProductDetails.tsx
+++ b/src/pages/ProductDetails.tsx
@@ -1,0 +1,42 @@
+// src/pages/ProductDetails.tsx
+// P4: Vista de producto escaneado o buscado
+
+import { IonPage, IonContent, IonHeader, IonToolbar, IonTitle } from '@ionic/react';
+import { ProductInfo, calculateScore, getRecommendations } from '../services/recommendations';
+import { RadarChart } from '../components/RadarChart';
+
+interface Props {
+  product: ProductInfo;
+}
+
+export const ProductDetails: React.FC<Props> = ({ product }) => {
+  const score = calculateScore(product);
+  const recommendations = getRecommendations(score);
+
+  // Example radar data
+  const data = {
+    labels: ['Azúcar', 'Grasas', 'Sal', 'Fibra', 'Proteína'],
+    datasets: [{
+      data: [product.nutrients.sugar, product.nutrients.fat, product.nutrients.salt, product.nutrients.fiber, product.nutrients.protein],
+      label: product.name
+    }]
+  };
+
+  return (
+    <IonPage>
+      <IonHeader>
+        <IonToolbar>
+          <IonTitle>{product.name}</IonTitle>
+        </IonToolbar>
+      </IonHeader>
+      <IonContent className="ion-padding">
+        <RadarChart data={data} />
+        <p>Puntaje: {score}</p>
+        <ul>
+          {recommendations.map(r => <li key={r}>{r}</li>)}
+        </ul>
+        {/* TODO: enlace a IngredientAnalysis */}
+      </IonContent>
+    </IonPage>
+  );
+};

--- a/src/pages/ProfileSetup.tsx
+++ b/src/pages/ProfileSetup.tsx
@@ -1,0 +1,52 @@
+// src/pages/ProfileSetup.tsx
+// P3: Configuración rápida de perfil
+
+import { IonPage, IonContent, IonItem, IonLabel, IonInput, IonSelect, IonSelectOption, IonButton } from '@ionic/react';
+import { useState } from 'react';
+
+interface Profile {
+  age: number;
+  gender: string;
+  condition: string;
+}
+
+export const ProfileSetup: React.FC = () => {
+  const [profile, setProfile] = useState<Profile>({ age: 0, gender: '', condition: '' });
+
+  const saveProfile = () => {
+    // TODO: persist profile, then navigate to main menu
+  };
+
+  return (
+    <IonPage>
+      <IonContent className="ion-padding">
+        <IonItem>
+          <IonLabel position="stacked">Edad</IonLabel>
+          <IonInput
+            type="number"
+            value={profile.age}
+            onIonChange={e => setProfile({ ...profile, age: parseInt(e.detail.value!, 10) })}
+          />
+        </IonItem>
+        <IonItem>
+          <IonLabel position="stacked">Género</IonLabel>
+          <IonSelect
+            value={profile.gender}
+            onIonChange={e => setProfile({ ...profile, gender: e.detail.value })}
+          >
+            <IonSelectOption value="male">Masculino</IonSelectOption>
+            <IonSelectOption value="female">Femenino</IonSelectOption>
+          </IonSelect>
+        </IonItem>
+        <IonItem>
+          <IonLabel position="stacked">Condición</IonLabel>
+          <IonInput
+            value={profile.condition}
+            onIonChange={e => setProfile({ ...profile, condition: e.detail.value! })}
+          />
+        </IonItem>
+        <IonButton expand="block" onClick={saveProfile}>Guardar</IonButton>
+      </IonContent>
+    </IonPage>
+  );
+};

--- a/src/pages/Recommendation.tsx
+++ b/src/pages/Recommendation.tsx
@@ -1,0 +1,27 @@
+// src/pages/Recommendation.tsx
+// P7: Mostrar recomendaciones automáticas y explicación del producto
+
+import { IonPage, IonContent } from '@ionic/react';
+import { ProductInfo, calculateScore, getRecommendations } from '../services/recommendations';
+
+interface Props {
+  product: ProductInfo;
+}
+
+export const RecommendationPage: React.FC<Props> = ({ product }) => {
+  const score = calculateScore(product);
+  const recommendations = getRecommendations(score);
+
+  return (
+    <IonPage>
+      <IonContent className="ion-padding">
+        <h2>{product.name}</h2>
+        <p>Puntaje: {score}</p>
+        <p>{/* TODO: short product explanation */}</p>
+        <ul>
+          {recommendations.map(r => <li key={r}>{r}</li>)}
+        </ul>
+      </IonContent>
+    </IonPage>
+  );
+};

--- a/src/pages/SearchProduct.tsx
+++ b/src/pages/SearchProduct.tsx
@@ -1,0 +1,36 @@
+// src/pages/SearchProduct.tsx
+// P6: Búsqueda de productos con acceso directo al escaneo
+
+import { IonPage, IonContent, IonSearchbar, IonList, IonItem, IonButton } from '@ionic/react';
+import { useState } from 'react';
+import { searchProducts } from '../services/database';
+import { ProductInfo } from '../services/recommendations';
+import { scanBarcode } from '../services/barcode';
+
+export const SearchProduct: React.FC = () => {
+  const [results, setResults] = useState<ProductInfo[]>([]);
+
+  const search = async (text: string) => {
+    const found = await searchProducts(text);
+    setResults(found as ProductInfo[]);
+  };
+
+  const handleScan = async () => {
+    const barcode = await scanBarcode();
+    // TODO: navigate to product page using barcode
+  };
+
+  return (
+    <IonPage>
+      <IonContent>
+        <IonSearchbar onIonChange={e => search(e.detail.value!)} />
+        <IonButton onClick={handleScan}>Escanear</IonButton>
+        <IonList>
+          {results.map(p => (
+            <IonItem key={p.name}>{p.name}</IonItem>
+          ))}
+        </IonList>
+      </IonContent>
+    </IonPage>
+  );
+};

--- a/src/pages/WelcomePage.tsx
+++ b/src/pages/WelcomePage.tsx
@@ -1,0 +1,15 @@
+// src/pages/WelcomePage.tsx
+// P1: Pantalla de bienvenida con logo
+
+import { IonPage, IonContent, IonImg } from '@ionic/react';
+
+export const WelcomePage: React.FC = () => {
+  return (
+    <IonPage>
+      <IonContent className="ion-padding ion-text-center">
+        <IonImg src="assets/logo.png" alt="NutriScan AI logo" />
+        {/* TODO: add start button to navigate to MainMenu */}
+      </IonContent>
+    </IonPage>
+  );
+};

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,0 +1,10 @@
+// src/routes.tsx
+// Centralized route definitions for scalability
+
+export const routes = {
+  welcome: '/',
+  menu: '/menu',
+  profile: '/profile',
+  search: '/search',
+  // TODO: add other routes
+};

--- a/src/services/barcode.ts
+++ b/src/services/barcode.ts
@@ -1,0 +1,13 @@
+// src/services/barcode.ts
+// Wrapper for Barcode scanning using Capacitor plugin
+
+import { BarcodeScanner } from '@capacitor-community/barcode-scanner';
+
+export async function scanBarcode(): Promise<string | null> {
+  await BarcodeScanner.checkPermission({ force: true });
+  const result = await BarcodeScanner.startScan();
+  if (result.hasContent) {
+    return result.content;
+  }
+  return null;
+}

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -1,0 +1,29 @@
+// src/services/database.ts
+// SQLite service for offline product storage
+
+import { CapacitorSQLite, SQLiteConnection, SQLiteDBConnection } from '@capacitor-community/sqlite';
+
+let db: SQLiteDBConnection | null = null;
+const sqlite = new SQLiteConnection(CapacitorSQLite);
+
+export async function initDatabase() {
+  if (db) return db;
+  db = await sqlite.createConnection('nutriscan', false, 'no-encryption', 1);
+  await db.open();
+  // example: load seed data if database empty
+  // TODO: implement check for existing tables
+  return db;
+}
+
+export async function getProductByBarcode(barcode: string) {
+  if (!db) await initDatabase();
+  const result = await db!.query('SELECT * FROM products WHERE barcode = ?', [barcode]);
+  return result.values?.[0];
+}
+
+export async function searchProducts(term: string) {
+  if (!db) await initDatabase();
+  const result = await db!.query('SELECT * FROM products WHERE name LIKE ?', [`%${term}%`]);
+  return result.values || [];
+}
+

--- a/src/services/ocr.ts
+++ b/src/services/ocr.ts
@@ -1,0 +1,9 @@
+// src/services/ocr.ts
+// Wrapper for OCR using Tesseract.js
+
+import Tesseract from 'tesseract.js';
+
+export async function recognizeText(image: File | Blob): Promise<string> {
+  const { data: { text } } = await Tesseract.recognize(image, 'eng');
+  return text;
+}

--- a/src/services/recommendations.ts
+++ b/src/services/recommendations.ts
@@ -1,0 +1,20 @@
+// src/services/recommendations.ts
+// Simple scoring system and automatic recommendations
+
+export interface ProductInfo {
+  name: string;
+  nutrients: Record<string, number>; // e.g., sugar, fat, salt
+}
+
+export function calculateScore(product: ProductInfo): number {
+  // TODO: implement better scoring
+  const sugar = product.nutrients.sugar || 0;
+  const fat = product.nutrients.fat || 0;
+  return 100 - sugar - fat;
+}
+
+export function getRecommendations(score: number): string[] {
+  if (score > 80) return ['Excelente elección'];
+  if (score > 60) return ['Consumir con moderación'];
+  return ['Busca alternativas más saludables'];
+}


### PR DESCRIPTION
## Summary
- create core folder structure for Ionic+Capacitor app NutriScan AI
- add reusable chart and card components
- provide pages P1–P9 with example state and navigation
- implement simple services for SQLite, barcode scan, OCR and recommendations
- seed SQLite with demo products

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685f43dc0bac832297fdfabfe385644e